### PR TITLE
Use `replaceEmptyString` when costructing the request body for `/api/…

### DIFF
--- a/src/lib/server/api/v1/task_api.js
+++ b/src/lib/server/api/v1/task_api.js
@@ -46,6 +46,8 @@ export async function createTask(fetch, formData) {
 		input_type: formData.get('input_type'),
 		output_type: formData.get('output_type')
 	};
+
+
 	// There is an interesting thing, if we use the svelte kit fetch object the server will not
 	// accept our request. If, instead, we use the default javascript fetch the server accepts it.
 	const response = await fetch(FRACTAL_SERVER_HOST + '/api/v1/task/', {
@@ -62,6 +64,17 @@ export async function createTask(fetch, formData) {
 
 	throw new PostResourceException(await response.json());
 }
+
+// Replace empty string value with undefined, so that it will be ignored in JSON.stringify (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description)
+function replaceEmptyString(key, value) {
+  if (value === '') {
+    return undefined;
+  }
+  else {
+	  return value;
+  }
+}
+
 
 /**
  * Requests a task collection to the server
@@ -81,14 +94,12 @@ export async function createTaskCollection(fetch, formData) {
 		package_extras: formData.get('package_extras')
 	};
 
-    console.log(requestData) // FIXME This is to debug https://github.com/fractal-analytics-platform/fractal-web/issues/162
-
 	const response = await fetch(FRACTAL_SERVER_HOST + '/api/v1/task/collect/pip/', {
 		method: 'POST',
 		mode: 'cors',
 		credentials: 'include',
 		headers: headers,
-		body: JSON.stringify(requestData) // The body must be serialized to json since the server accepts application/json
+		body: JSON.stringify(requestData, replaceEmptyString)
 	});
 
 	if (response.ok) {


### PR DESCRIPTION
…v1/task/collect/pip/` (closes #162)