### PR TITLE
Modal refactoring

### DIFF
--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -1,0 +1,33 @@
+name: End-to-end tests
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  end_to_end_tests:
+    name: 'Node ${{ matrix.node-version }}'
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        node-version: ['16', '18', '20']
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run playwright tests (not implemented)
+        run: echo "Not implemented"

--- a/.github/workflows/lint_and_build.yaml
+++ b/.github/workflows/lint_and_build.yaml
@@ -1,4 +1,4 @@
-name: Check&Build
+name: Lint and build
 
 on:
   push:
@@ -7,18 +7,18 @@ on:
     branches: ['main']
 
 jobs:
-  check_and_build:
+  lint_and_build:
     name: 'Node ${{ matrix.node-version }}'
     runs-on: ubuntu-20.04
     timeout-minutes: 10
 
     strategy:
       matrix:
-        node-version: ['16', '18']
+        node-version: ['16', '18', '20']
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up node
         uses: actions/setup-node@v3
@@ -31,9 +31,6 @@ jobs:
 
       - name: Run static code analysis
         run: npx eslint .
-
-      - name: Run vitest tests
-        run: npm run test
 
       - name: Build site
         env:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,0 +1,33 @@
+name: Unit tests
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  unit_tests:
+    name: 'Node ${{ matrix.node-version }}'
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        node-version: ['16', '18', '20']
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run vitest tests
+        run: npm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 
+* Standardized modal management to fix some bugs (\#306).
 * Added proxy endpoints and refactored error propagation (\#288).
 * Remove use of deployment-type `fractal-server` variable (\#298).
 * Add a BSD3 license (\#300).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1953,9 +1953,9 @@
 			"dev": true
 		},
 		"node_modules/get-func-name": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-			"integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
 			"dev": true,
 			"engines": {
 				"node": "*"
@@ -3059,9 +3059,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.24",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
-			"integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
+			"version": "8.4.31",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/src/lib/components/common/ConfirmActionButton.svelte
+++ b/src/lib/components/common/ConfirmActionButton.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { displayStandardErrorAlert } from '$lib/common/errors';
+	import Modal from './Modal.svelte';
 
 	export let callbackAction = async () => {}; // A default empty function
 	export let style = 'primary';
@@ -8,8 +8,10 @@
 	export let buttonIcon = undefined;
 	export let modalId = undefined;
 	export let message = '';
+	/** @type {Modal} */
+	let modal;
 
-	const openModal = () => {
+	const onOpen = () => {
 		// Remove old errors
 		const errorAlert = document.getElementById(`errorAlert-${modalId}`);
 		if (errorAlert) {
@@ -21,48 +23,33 @@
 	 * Executes the callback handling possible errors
 	 */
 	const handleCallbackAction = async () => {
-		try {
-			// important: retrieve the modal before executing callbackAction(), because it could remove
-			// the container element and then cause issues with the hide function
-			// @ts-ignore
-			// eslint-disable-next-line no-undef
-			const modal = bootstrap.Modal.getInstance(document.getElementById(modalId));
-			await callbackAction();
-			modal.hide();
-		} catch (/** @type {any} */ error) {
-			displayStandardErrorAlert(error, `errorAlert-${modalId}`);
-		}
+		modal.confirmAndHide(callbackAction)
 	};
 </script>
 
-<div class="modal modal-lg" id={modalId}>
-	<div class="modal-dialog">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h1 class="modal-title fs-5">Confirm action</h1>
-				<button class="btn-close" data-bs-dismiss="modal" />
-			</div>
-			<div class="modal-body">
-				<p>You're about to:</p>
-				<p class="badge bg-{style} fs-6">{message}</p>
-				<p>Do you confirm?</p>
-			</div>
-			<div class="modal-footer">
-				<div class="container">
-					<div id="errorAlert-{modalId}" />
-				</div>
-				<button class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-				<button class="btn btn-primary" on:click={handleCallbackAction}>Confirm</button>
-			</div>
-		</div>
+<Modal id={modalId} {onOpen} bind:this={modal}>
+	<div class="modal-header">
+		<h1 class="modal-title fs-5">Confirm action</h1>
+		<button class="btn-close" data-bs-dismiss="modal" />
 	</div>
-</div>
+	<div class="modal-body">
+		<p>You're about to:</p>
+		<p class="badge bg-{style} fs-6">{message}</p>
+		<p>Do you confirm?</p>
+	</div>
+	<div class="modal-footer">
+		<div class="container">
+			<div id="errorAlert-{modalId}" />
+		</div>
+		<button class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+		<button class="btn btn-primary" on:click={handleCallbackAction}>Confirm</button>
+	</div>
+</Modal>
 
 <button
 	class="btn btn-{btnStyle}"
 	data-bs-toggle="modal"
 	data-bs-target="#{modalId}"
-	on:click={openModal}
 >
 	{#if buttonIcon}
 		<i class="bi bi-{buttonIcon}" />

--- a/src/lib/components/common/ConfirmActionButton.svelte
+++ b/src/lib/components/common/ConfirmActionButton.svelte
@@ -23,34 +23,29 @@
 	 * Executes the callback handling possible errors
 	 */
 	const handleCallbackAction = async () => {
-		modal.confirmAndHide(callbackAction)
+		modal.confirmAndHide(callbackAction);
 	};
 </script>
 
-<Modal id={modalId} {onOpen} bind:this={modal}>
-	<div class="modal-header">
+<Modal id={modalId} {onOpen} bind:this={modal} size="lg">
+	<svelte:fragment slot="header">
 		<h1 class="modal-title fs-5">Confirm action</h1>
-		<button class="btn-close" data-bs-dismiss="modal" />
-	</div>
-	<div class="modal-body">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<p>You're about to:</p>
 		<p class="badge bg-{style} fs-6">{message}</p>
 		<p>Do you confirm?</p>
-	</div>
-	<div class="modal-footer">
 		<div class="container">
 			<div id="errorAlert-{modalId}" />
 		</div>
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
 		<button class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
 		<button class="btn btn-primary" on:click={handleCallbackAction}>Confirm</button>
-	</div>
+	</svelte:fragment>
 </Modal>
 
-<button
-	class="btn btn-{btnStyle}"
-	data-bs-toggle="modal"
-	data-bs-target="#{modalId}"
->
+<button class="btn btn-{btnStyle}" data-bs-toggle="modal" data-bs-target="#{modalId}">
 	{#if buttonIcon}
 		<i class="bi bi-{buttonIcon}" />
 	{/if}

--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -10,6 +10,7 @@
 	export let fullscreen = false;
 	export let centered = false;
 	export let scrollable = false;
+	export let bodyCss = '';
 	let errorAlert;
 
 	onMount(async () => {
@@ -87,7 +88,18 @@
 		class:modal-dialog-scrollable={scrollable}
 	>
 		<div class="modal-content">
-			<slot />
+			<div class="modal-header">
+				<slot name="header" />
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
+			</div>
+			<div class="modal-body {bodyCss}">
+				<slot name="body" />
+			</div>
+			{#if !!$$slots.footer}
+			<div class="modal-footer">
+				<slot name="footer" />
+			</div>
+			{/if}
 		</div>
 	</div>
 </div>

--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -20,6 +20,13 @@
 				hideErrorAlert();
 				onOpen();
 			});
+			modal.addEventListener('shown.bs.modal', () => {
+				// Automatically set focus on first input element (if any)
+				const firstInput = document.querySelector(`#${id} input`);
+				if (firstInput instanceof HTMLElement) {
+					firstInput.focus();
+				}
+			});
 			modal.addEventListener('hidden.bs.modal', onClose);
 		}
 	});

--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -16,7 +16,7 @@
 		const modal = document.getElementById(id);
 		if (modal) {
 			modal.addEventListener('show.bs.modal', () => {
-				hidePreviousErrorAlert();
+				hideErrorAlert();
 				onOpen();
 			});
 			modal.addEventListener('hidden.bs.modal', onClose);
@@ -45,7 +45,7 @@
 		// the container element and then cause issues with the hide function
 		const modal = getBootstrapModal();
 		try {
-			hidePreviousErrorAlert();
+			hideErrorAlert();
 			await confirm();
 			modal.hide();
 		} catch (/** @type {any} */ error) {
@@ -53,10 +53,14 @@
 		}
 	}
 
-	function hidePreviousErrorAlert() {
+	export function hideErrorAlert() {
 		if (errorAlert) {
 			errorAlert.hide();
 		}
+	}
+
+	export function displayErrorAlert(/** @type {any} */ error) {
+		errorAlert = displayStandardErrorAlert(error, `errorAlert-${id}`);
 	}
 
 	function getBootstrapModal() {

--- a/src/lib/components/common/Modal.svelte
+++ b/src/lib/components/common/Modal.svelte
@@ -1,0 +1,89 @@
+<script>
+	import { displayStandardErrorAlert } from '$lib/common/errors';
+	import { onMount } from 'svelte';
+
+	export let id;
+	export let onOpen = () => {};
+	export let onClose = () => {};
+	/** @type {'sm'|'md'|'lg'|'xl'|undefined} */
+	export let size = undefined;
+	export let fullscreen = false;
+	export let centered = false;
+	export let scrollable = false;
+	let errorAlert;
+
+	onMount(async () => {
+		const modal = document.getElementById(id);
+		if (modal) {
+			modal.addEventListener('show.bs.modal', () => {
+				hidePreviousErrorAlert();
+				onOpen();
+			});
+			modal.addEventListener('hidden.bs.modal', onClose);
+		}
+	});
+
+	export function show() {
+		getBootstrapModal().show();
+	}
+
+	export function hide() {
+		getBootstrapModal().hide();
+	}
+
+	export function toggle() {
+		getBootstrapModal().toggle();
+	}
+
+	/**
+	 * Executes a callback function when the user confirm the modal action. If the callback is successful
+	 * the modal is closed, otherwise an error message is displayed.
+	 * @param {() => Promise<void>} confirm The asynchronous function to be executed before closing the modal
+	 */
+	export async function confirmAndHide(confirm) {
+		// important: retrieve the modal before executing confirm(), because it could remove
+		// the container element and then cause issues with the hide function
+		const modal = getBootstrapModal();
+		try {
+			hidePreviousErrorAlert();
+			await confirm();
+			modal.hide();
+		} catch (/** @type {any} */ error) {
+			errorAlert = displayStandardErrorAlert(error, `errorAlert-${id}`);
+		}
+	}
+
+	function hidePreviousErrorAlert() {
+		if (errorAlert) {
+			errorAlert.hide();
+		}
+	}
+
+	function getBootstrapModal() {
+		const modalElement = document.getElementById(id);
+		// @ts-ignore
+		// eslint-disable-next-line no-undef
+		const bootstrapModal = bootstrap.Modal.getInstance(modalElement);
+		if (bootstrapModal) {
+			return bootstrapModal;
+		}
+		// @ts-ignore
+		// eslint-disable-next-line no-undef
+		return new bootstrap.Modal(modalElement);
+	}
+</script>
+
+<!-- Note: tabindex="-1" is needed to fix escape key not working in some cases -->
+<!-- (see https://stackoverflow.com/a/12630531) -->
+<div class="modal {size ? 'modal-' + size : ''}" {id} tabindex="-1">
+	<div
+		class="modal-dialog"
+		class:modal-fullscreen={fullscreen}
+		class:modal-dialog-centered={centered}
+		class:modal-dialog-scrollable={scrollable}
+	>
+		<div class="modal-content">
+			<slot />
+		</div>
+	</div>
+</div>

--- a/src/lib/components/common/StandardDismissableAlert.svelte
+++ b/src/lib/components/common/StandardDismissableAlert.svelte
@@ -2,7 +2,18 @@
 	export let message;
 	export let autoDismiss = true;
 
-	$: if (autoDismiss && message) setTimeout(hide, 3000);
+	let timeout;
+
+	$: if (autoDismiss && message) {
+		console.log(`alertMessage=${message}`)
+		if (timeout) {
+			clearTimeout(timeout);
+		}
+		timeout = setTimeout(function () {
+			hide();
+			timeout = null;
+		}, 3000);
+	}
 
 	export function hide() {
 		message = '';

--- a/src/lib/components/common/StandardDismissableAlert.svelte
+++ b/src/lib/components/common/StandardDismissableAlert.svelte
@@ -1,0 +1,17 @@
+<script>
+	export let message;
+	export let autoDismiss = true;
+
+	$: if (autoDismiss && message) setTimeout(hide, 3000);
+
+	export function hide() {
+		message = '';
+	}
+</script>
+
+{#if message}
+	<div class="alert alert-success alert-dismissible fade show" role="alert">
+		{message}
+		<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" />
+	</div>
+{/if}

--- a/src/lib/components/jobs/JobInfoModal.svelte
+++ b/src/lib/components/jobs/JobInfoModal.svelte
@@ -55,16 +55,13 @@
 </script>
 
 <Modal id="workflowJobInfoModal" bind:this={modal} size="lg">
-	<div class="modal-header d-flex justify-content-between">
-		<h1 class="h5 modal-title">Workflow Job #{workflowJobId}</h1>
-		<div class="d-flex align-items-center">
-			<button class="btn btn-light me-3" on:click={fetchJob}>
-				<i class="bi-arrow-clockwise" />
-			</button>
-			<button class="btn-close bg-light p-2" data-bs-dismiss="modal" />
-		</div>
-	</div>
-	<div class="modal-body">
+	<svelte:fragment slot="header">
+		<h1 class="h5 modal-title flex-grow-1">Workflow Job #{workflowJobId}</h1>
+		<button class="btn btn-light me-3" on:click={fetchJob}>
+			<i class="bi-arrow-clockwise" />
+		</button>
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<div class="row mb-3">
 			<div class="col-12">
 				<div id="workflowJobError" />
@@ -94,5 +91,5 @@
 		<div class="row">
 			<div class="col-12" />
 		</div>
-	</div>
+	</svelte:fragment>
 </Modal>

--- a/src/lib/components/jobs/JobInfoModal.svelte
+++ b/src/lib/components/jobs/JobInfoModal.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/stores';
 	import StatusBadge from '$lib/components/jobs/StatusBadge.svelte';
 	import { displayStandardErrorAlert } from '$lib/common/errors';
+	import Modal from '../common/Modal.svelte';
 
 	let workflowJobId = undefined;
 	let job = undefined;
@@ -14,6 +15,8 @@
 	let jobStatus = undefined;
 
 	let errorAlert = undefined;
+	/** @type {Modal} */
+	let modal;
 
 	export async function show(jobId) {
 		workflowJobId = jobId;
@@ -27,9 +30,6 @@
 		// Should update jobStatus
 		jobStatus = job.status;
 
-		// @ts-ignore
-		// eslint-disable-next-line
-		const modal = new bootstrap.Modal(document.getElementById('workflowJobInfoModal'), {});
 		modal.show();
 	}
 
@@ -54,49 +54,45 @@
 	}
 </script>
 
-<div class="modal modal-lg" id="workflowJobInfoModal">
-	<div class="modal-dialog">
-		<div class="modal-content">
-			<div class="modal-header d-flex justify-content-between">
-				<h1 class="h5 modal-title">Workflow Job #{workflowJobId}</h1>
-				<div class="d-flex align-items-center">
-					<button class="btn btn-light me-3" on:click={fetchJob}>
-						<i class="bi-arrow-clockwise" />
-					</button>
-					<button class="btn-close bg-light p-2" data-bs-dismiss="modal" />
-				</div>
-			</div>
-			<div class="modal-body">
-				<div class="row mb-3">
-					<div class="col-12">
-						<div id="workflowJobError" />
-						<p class="lead">Workflow job properties</p>
-						<ul class="list-group">
-							<li class="list-group-item list-group-item-light fw-bold">Id</li>
-							<li class="list-group-item">{job?.id}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Workflow</li>
-							<li class="list-group-item">{jobWorkflowName}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Project</li>
-							<li class="list-group-item">{projectName}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Input dataset</li>
-							<li class="list-group-item">{jobInputDatasetName}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Output dataset</li>
-							<li class="list-group-item">{jobOutputDatasetName}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Status</li>
-							{#key jobStatus}
-								<li class="list-group-item"><StatusBadge status={jobStatus} /></li>
-							{/key}
-							<li class="list-group-item list-group-item-light fw-bold">Working directory</li>
-							<li class="list-group-item"><code>{job?.working_dir}</code></li>
-							<li class="list-group-item list-group-item-light fw-bold">User Working directory</li>
-							<li class="list-group-item"><code>{job?.working_dir_user}</code></li>
-						</ul>
-					</div>
-				</div>
-				<div class="row">
-					<div class="col-12" />
-				</div>
-			</div>
+<Modal id="workflowJobInfoModal" bind:this={modal} size="lg">
+	<div class="modal-header d-flex justify-content-between">
+		<h1 class="h5 modal-title">Workflow Job #{workflowJobId}</h1>
+		<div class="d-flex align-items-center">
+			<button class="btn btn-light me-3" on:click={fetchJob}>
+				<i class="bi-arrow-clockwise" />
+			</button>
+			<button class="btn-close bg-light p-2" data-bs-dismiss="modal" />
 		</div>
 	</div>
-</div>
+	<div class="modal-body">
+		<div class="row mb-3">
+			<div class="col-12">
+				<div id="workflowJobError" />
+				<p class="lead">Workflow job properties</p>
+				<ul class="list-group">
+					<li class="list-group-item list-group-item-light fw-bold">Id</li>
+					<li class="list-group-item">{job?.id}</li>
+					<li class="list-group-item list-group-item-light fw-bold">Workflow</li>
+					<li class="list-group-item">{jobWorkflowName}</li>
+					<li class="list-group-item list-group-item-light fw-bold">Project</li>
+					<li class="list-group-item">{projectName}</li>
+					<li class="list-group-item list-group-item-light fw-bold">Input dataset</li>
+					<li class="list-group-item">{jobInputDatasetName}</li>
+					<li class="list-group-item list-group-item-light fw-bold">Output dataset</li>
+					<li class="list-group-item">{jobOutputDatasetName}</li>
+					<li class="list-group-item list-group-item-light fw-bold">Status</li>
+					{#key jobStatus}
+						<li class="list-group-item"><StatusBadge status={jobStatus} /></li>
+					{/key}
+					<li class="list-group-item list-group-item-light fw-bold">Working directory</li>
+					<li class="list-group-item"><code>{job?.working_dir}</code></li>
+					<li class="list-group-item list-group-item-light fw-bold">User Working directory</li>
+					<li class="list-group-item"><code>{job?.working_dir_user}</code></li>
+				</ul>
+			</div>
+		</div>
+		<div class="row">
+			<div class="col-12" />
+		</div>
+	</div>
+</Modal>

--- a/src/lib/components/jobs/JobLogsModal.svelte
+++ b/src/lib/components/jobs/JobLogsModal.svelte
@@ -1,10 +1,13 @@
 <script>
 	import { page } from '$app/stores';
 	import { displayStandardErrorAlert } from '$lib/common/errors';
+	import Modal from '../common/Modal.svelte';
 
 	let workflowJobId = undefined;
 	let logs = '';
 	let errorAlert = undefined;
+	/** @type {Modal} */
+	let modal;
 
 	export async function show(jobId) {
 		workflowJobId = jobId;
@@ -17,9 +20,6 @@
 		const job = await fetchJob();
 		logs = job?.log || '';
 
-		// @ts-ignore
-		// eslint-disable-next-line
-		const modal = new bootstrap.Modal(document.getElementById('workflowJobLogsModal'), {});
 		modal.show();
 	}
 
@@ -39,17 +39,13 @@
 	}
 </script>
 
-<div class="modal" id="workflowJobLogsModal">
-	<div class="modal-dialog modal-fullscreen">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h1 class="h5 modal-title">Workflow Job logs</h1>
-				<button class="btn-close" data-bs-dismiss="modal" />
-			</div>
-			<div class="modal-body bg-tertiary text-secondary">
-				<div id="workflowJobLogsError" />
-				<pre>{logs}</pre>
-			</div>
-		</div>
+<Modal id="workflowJobLogsModal" fullscreen={true} bind:this={modal}>
+	<div class="modal-header">
+		<h1 class="h5 modal-title">Workflow Job logs</h1>
+		<button class="btn-close" data-bs-dismiss="modal" />
 	</div>
-</div>
+	<div class="modal-body bg-tertiary text-secondary">
+		<div id="workflowJobLogsError" />
+		<pre>{logs}</pre>
+	</div>
+</Modal>

--- a/src/lib/components/jobs/JobLogsModal.svelte
+++ b/src/lib/components/jobs/JobLogsModal.svelte
@@ -39,13 +39,17 @@
 	}
 </script>
 
-<Modal id="workflowJobLogsModal" fullscreen={true} bind:this={modal}>
-	<div class="modal-header">
+<Modal
+	id="workflowJobLogsModal"
+	fullscreen={true}
+	bind:this={modal}
+	bodyCss="bg-tertiary text-secondary"
+>
+	<svelte:fragment slot="header">
 		<h1 class="h5 modal-title">Workflow Job logs</h1>
-		<button class="btn-close" data-bs-dismiss="modal" />
-	</div>
-	<div class="modal-body bg-tertiary text-secondary">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<div id="workflowJobLogsError" />
 		<pre>{logs}</pre>
-	</div>
+	</svelte:fragment>
 </Modal>

--- a/src/lib/components/projects/ProjectInfoModal.svelte
+++ b/src/lib/components/projects/ProjectInfoModal.svelte
@@ -1,5 +1,4 @@
 <script>
-	import { goto } from '$app/navigation';
 	// ProjectInfoModal component
 	import { modalProject } from '$lib/stores/projectStores';
 	import Modal from '../common/Modal.svelte';

--- a/src/lib/components/projects/ProjectInfoModal.svelte
+++ b/src/lib/components/projects/ProjectInfoModal.svelte
@@ -16,21 +16,13 @@
 </script>
 
 <Modal id="projectInfoModal" size="lg">
-	<div class="modal-header d-flex justify-content-between">
-		<h1 class="h5 modal-title">Project {project?.name}</h1>
-		<div class="d-flex align-items-center">
-			<button
-				class="btn btn-light me-3"
-				data-bs-dismiss="modal"
-				on:click={() => {
-					// This method is required in order to correctly dismissing the modal
-					goto('/projects/' + project.id);
-				}}>Open <i class="bi bi-arrow-up-right-square" /></button
-			>
-			<button class="btn-close bg-light p-2" data-bs-dismiss="modal" />
-		</div>
-	</div>
-	<div class="modal-body">
+	<svelte:fragment slot="header">
+		<h1 class="h5 modal-title flex-grow-1">Project {project?.name}</h1>
+		<a href={'/projects/' + project.id} class="btn btn-light me-3">
+			Open <i class="bi bi-arrow-up-right-square" />
+		</a>
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<div class="row mb-3">
 			<div class="col-12">
 				<p class="lead">Project properties</p>
@@ -69,5 +61,5 @@
 				{/if}
 			</div>
 		</div>
-	</div>
+	</svelte:fragment>
 </Modal>

--- a/src/lib/components/projects/ProjectInfoModal.svelte
+++ b/src/lib/components/projects/ProjectInfoModal.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	// ProjectInfoModal component
 	import { modalProject } from '$lib/stores/projectStores';
+	import Modal from '../common/Modal.svelte';
 
 	// Project to be displayed
 	let project = {};
@@ -14,63 +15,59 @@
 	});
 </script>
 
-<div class="modal modal-lg" id="projectInfoModal">
-	<div class="modal-dialog">
-		<div class="modal-content">
-			<div class="modal-header d-flex justify-content-between">
-				<h1 class="h5 modal-title">Project {project?.name}</h1>
-				<div class="d-flex align-items-center">
-					<button
-						class="btn btn-light me-3"
-						data-bs-dismiss="modal"
-						on:click={() => {
-							// This method is required in order to correctly dismissing the modal
-							goto('/projects/' + project.id);
-						}}>Open <i class="bi bi-arrow-up-right-square" /></button
-					>
-					<button class="btn-close bg-light p-2" data-bs-dismiss="modal" />
-				</div>
+<Modal id="projectInfoModal" size="lg">
+	<div class="modal-header d-flex justify-content-between">
+		<h1 class="h5 modal-title">Project {project?.name}</h1>
+		<div class="d-flex align-items-center">
+			<button
+				class="btn btn-light me-3"
+				data-bs-dismiss="modal"
+				on:click={() => {
+					// This method is required in order to correctly dismissing the modal
+					goto('/projects/' + project.id);
+				}}>Open <i class="bi bi-arrow-up-right-square" /></button
+			>
+			<button class="btn-close bg-light p-2" data-bs-dismiss="modal" />
+		</div>
+	</div>
+	<div class="modal-body">
+		<div class="row mb-3">
+			<div class="col-12">
+				<p class="lead">Project properties</p>
+				<ul class="list-group">
+					<li class="list-group-item list-group-item-light fw-bold">Name</li>
+					<li class="list-group-item">{project?.name}</li>
+					<li class="list-group-item list-group-item-light fw-bold">Read only</li>
+					<li class="list-group-item">{project?.read_only ? 'Yes' : 'No'}</li>
+				</ul>
 			</div>
-			<div class="modal-body">
-				<div class="row mb-3">
-					<div class="col-12">
-						<p class="lead">Project properties</p>
-						<ul class="list-group">
-							<li class="list-group-item list-group-item-light fw-bold">Name</li>
-							<li class="list-group-item">{project?.name}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Read only</li>
-							<li class="list-group-item">{project?.read_only ? 'Yes' : 'No'}</li>
-						</ul>
-					</div>
-				</div>
-				<div class="row">
-					<div class="col-12">
-						{#if project?.dataset_list}
-							<p class="lead">Datasets</p>
-							<table class="table">
-								<thead class="table-light">
-									<tr>
-										<th>Name</th>
-										<th>Readonly</th>
-										<th># Resources</th>
-										<th>Type</th>
-									</tr>
-								</thead>
-								<tbody>
-									{#each project?.dataset_list as { name, read_only, resource_list, type }}
-										<tr>
-											<td>{name}</td>
-											<td>{read_only ? 'Yes' : 'No'}</td>
-											<td>{resource_list.length}</td>
-											<td>{type == '' ? 'Unknown' : type}</td>
-										</tr>
-									{/each}
-								</tbody>
-							</table>
-						{/if}
-					</div>
-				</div>
+		</div>
+		<div class="row">
+			<div class="col-12">
+				{#if project?.dataset_list}
+					<p class="lead">Datasets</p>
+					<table class="table">
+						<thead class="table-light">
+							<tr>
+								<th>Name</th>
+								<th>Readonly</th>
+								<th># Resources</th>
+								<th>Type</th>
+							</tr>
+						</thead>
+						<tbody>
+							{#each project?.dataset_list as { name, read_only, resource_list, type }}
+								<tr>
+									<td>{name}</td>
+									<td>{read_only ? 'Yes' : 'No'}</td>
+									<td>{resource_list.length}</td>
+									<td>{type == '' ? 'Unknown' : type}</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				{/if}
 			</div>
 		</div>
 	</div>
-</div>
+</Modal>

--- a/src/lib/components/projects/WorkflowImport.svelte
+++ b/src/lib/components/projects/WorkflowImport.svelte
@@ -38,6 +38,9 @@
 			return;
 		}
 		importing = true;
+		if (errorAlert) {
+			errorAlert.hide();
+		}
 
 		const workflowFile = files[0];
 

--- a/src/lib/components/projects/WorkflowImport.svelte
+++ b/src/lib/components/projects/WorkflowImport.svelte
@@ -53,7 +53,7 @@
 			importing = false;
 			errorAlert = displayStandardErrorAlert(
 				'The workflow file is not a valid JSON file',
-				'importWorkflowError'
+				'errorAlert-importWorkflowModal'
 			);
 			return;
 		}
@@ -87,12 +87,12 @@
 			dispatch('workflowImported', workflow);
 		} else {
 			console.error('Import workflow failed', result);
-			errorAlert = displayStandardErrorAlert(result, 'importWorkflowError');
+			errorAlert = displayStandardErrorAlert(result, 'errorAlert-importWorkflowModal');
 		}
 	}
 </script>
 
-<div id="importWorkflowError" />
+<div id="errorAlert-importWorkflowModal" />
 
 <form on:submit|preventDefault={handleWorkflowImportForm}>
 	<div class="mb-3">

--- a/src/lib/components/projects/WorkflowsList.svelte
+++ b/src/lib/components/projects/WorkflowsList.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import WorkflowImport from '$lib/components/projects/WorkflowImport.svelte';
 	import ConfirmActionButton from '$lib/components/common/ConfirmActionButton.svelte';
-	import { displayStandardErrorAlert } from '$lib/common/errors';
+	import { AlertError, displayStandardErrorAlert } from '$lib/common/errors';
 	import Modal from '../common/Modal.svelte';
 
 	// The list of workflows
@@ -67,7 +67,7 @@
 		} else {
 			const result = await response.json();
 			console.error('Workflow not deleted', result);
-			displayStandardErrorAlert(result, 'workflowDeleteAlertError');
+			throw new AlertError(result);
 		}
 	}
 
@@ -91,7 +91,6 @@
 <div class="container p-0 mt-4">
 	<p class="lead">Workflows</p>
 	<div id="workflowCreateAlertError" />
-	<div id="workflowDeleteAlertError" />
 	<table class="table align-middle caption-top">
 		<caption class="text-bg-light border-top border-bottom pe-3 ps-3">
 			<div class="d-flex align-items-center justify-content-between">

--- a/src/lib/components/projects/WorkflowsList.svelte
+++ b/src/lib/components/projects/WorkflowsList.svelte
@@ -78,14 +78,16 @@
 	}
 </script>
 
-<Modal id="importWorkflowModal" size="lg" centered="{true}" scrollable={true}>
-	<div class="modal-header">
+<Modal id="importWorkflowModal" size="lg" centered={true} scrollable={true}>
+	<svelte:fragment slot="header">
 		<h5 class="modal-title">Import workflow</h5>
-		<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-	</div>
-	<div class="modal-body">
-		<WorkflowImport on:workflowImported={handleWorkflowImported} bind:this={workflowImportComponent} />
-	</div>
+	</svelte:fragment>
+	<svelte:fragment slot="body">
+		<WorkflowImport
+			on:workflowImported={handleWorkflowImported}
+			bind:this={workflowImportComponent}
+		/>
+	</svelte:fragment>
 </Modal>
 
 <div class="container p-0 mt-4">

--- a/src/lib/components/projects/WorkflowsList.svelte
+++ b/src/lib/components/projects/WorkflowsList.svelte
@@ -14,6 +14,8 @@
 	$: enableCreateWorkflow = !!newWorkflowName;
 	let validationError = false;
 
+	/** @type {Modal} */
+	let importWorkflowModal;
 	/** @type {WorkflowImport} */
 	let workflowImportComponent;
 
@@ -75,10 +77,11 @@
 		const importedWorkflow = event.detail;
 		workflows.push(importedWorkflow);
 		workflows = workflows;
+		goto(`/projects/${projectId}/workflows/${importedWorkflow.id}`);
 	}
 </script>
 
-<Modal id="importWorkflowModal" size="lg" centered={true} scrollable={true}>
+<Modal id="importWorkflowModal" size="lg" centered={true} scrollable={true} bind:this={importWorkflowModal}>
 	<svelte:fragment slot="header">
 		<h5 class="modal-title">Import workflow</h5>
 	</svelte:fragment>

--- a/src/lib/components/projects/WorkflowsList.svelte
+++ b/src/lib/components/projects/WorkflowsList.svelte
@@ -3,6 +3,7 @@
 	import WorkflowImport from '$lib/components/projects/WorkflowImport.svelte';
 	import ConfirmActionButton from '$lib/components/common/ConfirmActionButton.svelte';
 	import { displayStandardErrorAlert } from '$lib/common/errors';
+	import Modal from '../common/Modal.svelte';
 
 	// The list of workflows
 	export let workflows = [];
@@ -77,19 +78,15 @@
 	}
 </script>
 
-<div class="modal" id="importWorkflowModal">
-	<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h5 class="modal-title">Import workflow</h5>
-				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-			</div>
-			<div class="modal-body">
-				<WorkflowImport on:workflowImported={handleWorkflowImported} bind:this={workflowImportComponent} />
-			</div>
-		</div>
+<Modal id="importWorkflowModal" size="lg" centered="{true}" scrollable={true}>
+	<div class="modal-header">
+		<h5 class="modal-title">Import workflow</h5>
+		<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
 	</div>
-</div>
+	<div class="modal-body">
+		<WorkflowImport on:workflowImported={handleWorkflowImported} bind:this={workflowImportComponent} />
+	</div>
+</Modal>
 
 <div class="container p-0 mt-4">
 	<p class="lead">Workflows</p>

--- a/src/lib/components/tasks/TaskCollectionLogsModal.svelte
+++ b/src/lib/components/tasks/TaskCollectionLogsModal.svelte
@@ -30,13 +30,12 @@
 	});
 </script>
 
-<Modal id="collectionTaskLogsModal" fullscreen={true}>
-	<div class="modal-header">
+<Modal id="collectionTaskLogsModal" fullscreen={true} bodyCss="bg-tertiary text-secondary">
+	<svelte:fragment slot="header">
 		<h1 class="h5 modal-title">Task collection logs</h1>
-		<button class="btn-close" data-bs-dismiss="modal" />
-	</div>
-	<div class="modal-body bg-tertiary text-secondary">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<div id="collectionTaskLogsError" />
 		<pre>{logs}</pre>
-	</div>
+	</svelte:fragment>
 </Modal>

--- a/src/lib/components/tasks/TaskCollectionLogsModal.svelte
+++ b/src/lib/components/tasks/TaskCollectionLogsModal.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { displayStandardErrorAlert } from '$lib/common/errors';
 	import { modalTaskCollectionId } from '$lib/stores/taskStores';
+	import Modal from '../common/Modal.svelte';
 
 	let logs = '';
 	let errorAlert = undefined;
@@ -29,17 +30,13 @@
 	});
 </script>
 
-<div class="modal" id="collectionTaskLogsModal">
-	<div class="modal-dialog modal-fullscreen">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h1 class="h5 modal-title">Task collection logs</h1>
-				<button class="btn-close" data-bs-dismiss="modal" />
-			</div>
-			<div class="modal-body bg-tertiary text-secondary">
-				<div id="collectionTaskLogsError" />
-				<pre>{logs}</pre>
-			</div>
-		</div>
+<Modal id="collectionTaskLogsModal" fullscreen={true}>
+	<div class="modal-header">
+		<h1 class="h5 modal-title">Task collection logs</h1>
+		<button class="btn-close" data-bs-dismiss="modal" />
 	</div>
-</div>
+	<div class="modal-body bg-tertiary text-secondary">
+		<div id="collectionTaskLogsError" />
+		<pre>{logs}</pre>
+	</div>
+</Modal>

--- a/src/lib/components/tasks/TaskEditModal.svelte
+++ b/src/lib/components/tasks/TaskEditModal.svelte
@@ -1,7 +1,8 @@
 <script>
 	import { originalTaskStore, taskStore } from '$lib/stores/taskStores';
 	import { getOnlyModifiedProperties, nullifyEmptyStrings } from '$lib/common/component_utilities';
-	import { displayStandardErrorAlert } from '$lib/common/errors';
+	import { AlertError } from '$lib/common/errors';
+	import Modal from '../common/Modal.svelte';
 
 	export let updateEditedTask;
 	/** @type {import('$lib/types').Task|undefined} */
@@ -9,231 +10,226 @@
 	/** @type {import('$lib/types').Task|undefined} */
 	$: originalTask = $originalTaskStore;
 	$: updateEnabled = task && task.name && task.command && task.input_type && task.output_type;
+	/** @type {Modal} */
+	let modal;
+	let saved = false;
 
 	/**
 	 * Edits a task on the server
 	 * @returns {Promise<*>}
 	 */
 	async function handleEditTask() {
+		modal.confirmAndHide(async () => {
+			if (!task) {
+				return;
+			}
+
+			let taskProperties = nullifyEmptyStrings(task);
+			taskProperties = getOnlyModifiedProperties(originalTask, taskProperties);
+
+			console.log('Task to edit: ' + task.id);
+
+			const headers = new Headers();
+			headers.append('Content-Type', 'application/json');
+
+			const response = await fetch(`/api/v1/task/${task.id}`, {
+				method: 'PATCH',
+				credentials: 'include',
+				headers,
+				body: JSON.stringify(taskProperties)
+			});
+
+			if (!response.ok) {
+				throw new AlertError(await response.json());
+			}
+
+			console.log('Task updated successfully');
+			updateEditedTask(task);
+			saved = true;
+		});
+	}
+
+	async function onOpen() {
+		saved = false;
+	}
+
+	async function onClose() {
 		if (!task) {
 			return;
 		}
-
-		let taskProperties = nullifyEmptyStrings(task);
-		taskProperties = getOnlyModifiedProperties(originalTask, taskProperties);
-
-		console.log('Task to edit: ' + task.id);
-
-		const headers = new Headers();
-		headers.append('Content-Type', 'application/json');
-
-		const response = await fetch(`/api/v1/task/${task.id}`, {
-			method: 'PATCH',
-			credentials: 'include',
-			headers,
-			body: JSON.stringify(taskProperties)
-		});
-
-		if (response.ok) {
-			console.log('Task updated successfully');
-			updateEditedTask(task);
-			// @ts-ignore
-			// eslint-disable-next-line no-undef
-			const modal = bootstrap.Modal.getInstance(document.getElementById('taskEditModal'));
-			modal.hide();
-		} else {
-			displayStandardErrorAlert(await response.json(), 'editTaskErrorAlert');
-		}
-	}
-
-	async function undoChangesAndClose() {
-		if (!task) {
+		if (saved) {
 			return;
 		}
 		for (let key in originalTask) {
 			task[key] = originalTask[key];
 		}
-		// @ts-ignore
-		// eslint-disable-next-line no-undef
-		const modal = bootstrap.Modal.getInstance(document.getElementById('taskEditModal'));
-		modal.hide();
 	}
 </script>
 
-<div class="modal modal-xl" id="taskEditModal" data-bs-backdrop="static">
-	<div class="modal-dialog">
-		{#if task}
-			<div class="modal-content">
-				<div class="modal-header">
-					<h1 class="h5 modal-title">Task {task.name}</h1>
-				</div>
-				<div class="modal-body">
-					<div class="row mb-3">
-						<div class="col-12">
-							<p class="lead">Task properties</p>
+<Modal id="taskEditModal" {onOpen} {onClose} bind:this={modal} size="xl">
+	{#if task}
+		<div class="modal-header">
+			<h1 class="h5 modal-title">Task {task.name}</h1>
+		</div>
+		<div class="modal-body">
+			<div class="row mb-3">
+				<div class="col-12">
+					<p class="lead">Task properties</p>
 
-							<span id="editTaskErrorAlert" />
+					<span id="errorAlert-taskEditModal" />
 
-							<div class="mb-2 row">
-								<label for="taskName" class="col-2 col-form-label text-end">Name</label>
-								<div class="col-10">
-									<input
-										id="taskName"
-										type="text"
-										bind:value={task.name}
-										class="form-control"
-										class:is-invalid={!task.name}
-									/>
-									{#if !task.name}
-										<div class="invalid-feedback">Required field</div>
-									{/if}
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="taskName" class="col-2 col-form-label text-end">Name</label>
+						<div class="col-10">
+							<input
+								id="taskName"
+								type="text"
+								bind:value={task.name}
+								class="form-control"
+								class:is-invalid={!task.name}
+							/>
+							{#if !task.name}
+								<div class="invalid-feedback">Required field</div>
+							{/if}
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="version" class="col-2 col-form-label text-end">Version</label>
-								<div class="col-10">
-									<input id="version" type="text" bind:value={task.version} class="form-control" />
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="version" class="col-2 col-form-label text-end">Version</label>
+						<div class="col-10">
+							<input id="version" type="text" bind:value={task.version} class="form-control" />
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="owner" class="col-2 col-form-label text-end">Owner</label>
-								<div class="col-10">
-									<input
-										id="owner"
-										type="text"
-										bind:value={task.owner}
-										disabled
-										class="form-control"
-									/>
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="owner" class="col-2 col-form-label text-end">Owner</label>
+						<div class="col-10">
+							<input id="owner" type="text" bind:value={task.owner} disabled class="form-control" />
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="command" class="col-2 col-form-label text-end">Command</label>
-								<div class="col-10">
-									<input
-										id="command"
-										type="text"
-										bind:value={task.command}
-										class="form-control"
-										class:is-invalid={!task.command}
-									/>
-									{#if !task.command}
-										<div class="invalid-feedback">Required field</div>
-									{/if}
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="command" class="col-2 col-form-label text-end">Command</label>
+						<div class="col-10">
+							<input
+								id="command"
+								type="text"
+								bind:value={task.command}
+								class="form-control"
+								class:is-invalid={!task.command}
+							/>
+							{#if !task.command}
+								<div class="invalid-feedback">Required field</div>
+							{/if}
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="source" class="col-2 col-form-label text-end">Source</label>
-								<div class="col-10">
-									<input
-										id="source"
-										type="text"
-										bind:value={task.source}
-										disabled
-										class="form-control"
-									/>
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="source" class="col-2 col-form-label text-end">Source</label>
+						<div class="col-10">
+							<input
+								id="source"
+								type="text"
+								bind:value={task.source}
+								disabled
+								class="form-control"
+							/>
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="inputType" class="col-2 col-form-label text-end">Input Type</label>
-								<div class="col-10">
-									<input
-										id="inputType"
-										type="text"
-										bind:value={task.input_type}
-										class="form-control"
-										class:is-invalid={!task.input_type}
-									/>
-									{#if !task.input_type}
-										<div class="invalid-feedback">Required field</div>
-									{/if}
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="inputType" class="col-2 col-form-label text-end">Input Type</label>
+						<div class="col-10">
+							<input
+								id="inputType"
+								type="text"
+								bind:value={task.input_type}
+								class="form-control"
+								class:is-invalid={!task.input_type}
+							/>
+							{#if !task.input_type}
+								<div class="invalid-feedback">Required field</div>
+							{/if}
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="outputType" class="col-2 col-form-label text-end">Output Type</label>
-								<div class="col-10">
-									<input
-										id="outputType"
-										type="text"
-										bind:value={task.output_type}
-										class="form-control"
-										class:is-invalid={!task.output_type}
-									/>
-									{#if !task.output_type}
-										<div class="invalid-feedback">Required field</div>
-									{/if}
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="outputType" class="col-2 col-form-label text-end">Output Type</label>
+						<div class="col-10">
+							<input
+								id="outputType"
+								type="text"
+								bind:value={task.output_type}
+								class="form-control"
+								class:is-invalid={!task.output_type}
+							/>
+							{#if !task.output_type}
+								<div class="invalid-feedback">Required field</div>
+							{/if}
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="argsSchemaVersion" class="col-2 col-form-label text-end"
-									>Args Schema Version</label
-								>
-								<div class="col-10">
-									<input
-										id="ar$gsSchemaVersion"
-										type="text"
-										bind:value={task.args_schema_version}
-										disabled
-										class="form-control"
-									/>
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="argsSchemaVersion" class="col-2 col-form-label text-end"
+							>Args Schema Version</label
+						>
+						<div class="col-10">
+							<input
+								id="ar$gsSchemaVersion"
+								type="text"
+								bind:value={task.args_schema_version}
+								disabled
+								class="form-control"
+							/>
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="argsSchema" class="col-2 col-form-label text-end">Args Schema</label>
-								<div class="col-10">
-									<textarea
-										name="argsSchema"
-										value={JSON.stringify(task.args_schema, null, 2)}
-										disabled
-										class="form-control"
-										rows="10"
-									/>
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="argsSchema" class="col-2 col-form-label text-end">Args Schema</label>
+						<div class="col-10">
+							<textarea
+								name="argsSchema"
+								value={JSON.stringify(task.args_schema, null, 2)}
+								disabled
+								class="form-control"
+								rows="10"
+							/>
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="docsLink" class="col-2 col-form-label text-end">Docs Link</label>
-								<div class="col-10">
-									<input
-										id="docsLink"
-										type="text"
-										bind:value={task.docs_link}
-										disabled
-										class="form-control"
-									/>
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="docsLink" class="col-2 col-form-label text-end">Docs Link</label>
+						<div class="col-10">
+							<input
+								id="docsLink"
+								type="text"
+								bind:value={task.docs_link}
+								disabled
+								class="form-control"
+							/>
+						</div>
+					</div>
 
-							<div class="mb-2 row">
-								<label for="docsInfo" class="col-2 col-form-label text-end">Docs Info</label>
-								<div class="col-10">
-									<textarea
-										id="docsInfo"
-										bind:value={task.docs_info}
-										disabled
-										class="form-control"
-										rows="5"
-									/>
-								</div>
-							</div>
+					<div class="mb-2 row">
+						<label for="docsInfo" class="col-2 col-form-label text-end">Docs Info</label>
+						<div class="col-10">
+							<textarea
+								id="docsInfo"
+								bind:value={task.docs_info}
+								disabled
+								class="form-control"
+								rows="5"
+							/>
 						</div>
 					</div>
 				</div>
-				<div class="modal-footer">
-					<button class="btn btn-primary" on:click={handleEditTask} disabled={!updateEnabled}>
-						Update
-					</button>
-					<button class="btn btn-secondary" on:click={undoChangesAndClose}>Close</button>
-				</div>
 			</div>
-		{/if}
-	</div>
-</div>
+		</div>
+		<div class="modal-footer">
+			<button class="btn btn-primary" on:click={handleEditTask} disabled={!updateEnabled}>
+				Update
+			</button>
+			<button class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+		</div>
+	{/if}
+</Modal>

--- a/src/lib/components/tasks/TaskEditModal.svelte
+++ b/src/lib/components/tasks/TaskEditModal.svelte
@@ -67,11 +67,13 @@
 </script>
 
 <Modal id="taskEditModal" {onOpen} {onClose} bind:this={modal} size="xl">
-	{#if task}
-		<div class="modal-header">
+	<svelte:fragment slot="header">
+		{#if task}
 			<h1 class="h5 modal-title">Task {task.name}</h1>
-		</div>
-		<div class="modal-body">
+		{/if}
+	</svelte:fragment>
+	<svelte:fragment slot="body">
+		{#if task}
 			<div class="row mb-3">
 				<div class="col-12">
 					<p class="lead">Task properties</p>
@@ -224,12 +226,14 @@
 					</div>
 				</div>
 			</div>
-		</div>
-		<div class="modal-footer">
+		{/if}
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
+		{#if task}
 			<button class="btn btn-primary" on:click={handleEditTask} disabled={!updateEnabled}>
 				Update
 			</button>
 			<button class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-		</div>
-	{/if}
+		{/if}
+	</svelte:fragment>
 </Modal>

--- a/src/lib/components/tasks/TaskInfoModal.svelte
+++ b/src/lib/components/tasks/TaskInfoModal.svelte
@@ -18,12 +18,13 @@
 </script>
 
 <Modal id="taskInfoModal" size="xl">
-	{#if task}
-		<div class="modal-header">
+	<svelte:fragment slot="header">
+		{#if task}
 			<h1 class="h5 modal-title">Task {task.name}</h1>
-			<button class="btn-close" data-bs-dismiss="modal" />
-		</div>
-		<div class="modal-body">
+		{/if}
+	</svelte:fragment>
+	<svelte:fragment slot="body">
+		{#if task}
 			<div class="row mb-3">
 				<div class="col-12">
 					<p class="lead">Task properties</p>
@@ -77,9 +78,9 @@
 					</ul>
 				</div>
 			</div>
-		</div>
-		<div class="modal-footer">
-			<button class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-		</div>
-	{/if}
+		{/if}
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
+		<button class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+	</svelte:fragment>
 </Modal>

--- a/src/lib/components/tasks/TaskInfoModal.svelte
+++ b/src/lib/components/tasks/TaskInfoModal.svelte
@@ -3,6 +3,7 @@
 
 	// TaskInfoModal component
 	import { taskStore } from '$lib/stores/taskStores';
+	import Modal from '../common/Modal.svelte';
 
 	// Task to be displayed
 	// let task = {}
@@ -16,71 +17,69 @@
 	$: task = $taskStore;
 </script>
 
-<div class="modal modal-xl" id="taskInfoModal">
-	<div class="modal-dialog">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h1 class="h5 modal-title">Task {task?.name}</h1>
-				<button class="btn-close" data-bs-dismiss="modal" />
-			</div>
-			<div class="modal-body">
-				<div class="row mb-3">
-					<div class="col-12">
-						<p class="lead">Task properties</p>
-						<ul class="list-group">
-							<li class="list-group-item list-group-item-light fw-bold">Name</li>
-							<li class="list-group-item">{task?.name}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Version</li>
-							<li class="list-group-item">{task?.version || '-'}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Owner</li>
-							<li class="list-group-item">{task?.owner || '-'}</li>
-							<li class="list-group-item list-group-item-light fw-bold">Command</li>
-							<li class='list-group-item'><code>{task?.command}</code></li>
-							<li class='list-group-item list-group-item-light fw-bold'>Source</li>
-							<li class='list-group-item'><code>{task?.source}</code></li>
-							<li class='list-group-item list-group-item-light fw-bold'>Input Type</li>
-							<li class='list-group-item'>
-								<code>{task?.input_type}</code>
-							</li>
-							<li class='list-group-item list-group-item-light fw-bold'>Output Type</li>
-							<li class='list-group-item'>
-								<code>{task?.output_type}</code>
-							</li>
-							<li class='list-group-item list-group-item-light fw-bold'>Args Schema Version</li>
-							<li class='list-group-item'>{task?.args_schema_version || '-'}</li>
-							<li class='list-group-item list-group-item-light fw-bold'>Args Schema</li>
-							<li class='list-group-item'>
-								{#if task?.args_schema}
+<Modal id="taskInfoModal" size="xl">
+	{#if task}
+		<div class="modal-header">
+			<h1 class="h5 modal-title">Task {task.name}</h1>
+			<button class="btn-close" data-bs-dismiss="modal" />
+		</div>
+		<div class="modal-body">
+			<div class="row mb-3">
+				<div class="col-12">
+					<p class="lead">Task properties</p>
+					<ul class="list-group">
+						<li class="list-group-item list-group-item-light fw-bold">Name</li>
+						<li class="list-group-item">{task.name}</li>
+						<li class="list-group-item list-group-item-light fw-bold">Version</li>
+						<li class="list-group-item">{task.version || '-'}</li>
+						<li class="list-group-item list-group-item-light fw-bold">Owner</li>
+						<li class="list-group-item">{task.owner || '-'}</li>
+						<li class="list-group-item list-group-item-light fw-bold">Command</li>
+						<li class="list-group-item"><code>{task.command}</code></li>
+						<li class="list-group-item list-group-item-light fw-bold">Source</li>
+						<li class="list-group-item"><code>{task.source}</code></li>
+						<li class="list-group-item list-group-item-light fw-bold">Input Type</li>
+						<li class="list-group-item">
+							<code>{task.input_type}</code>
+						</li>
+						<li class="list-group-item list-group-item-light fw-bold">Output Type</li>
+						<li class="list-group-item">
+							<code>{task.output_type}</code>
+						</li>
+						<li class="list-group-item list-group-item-light fw-bold">Args Schema Version</li>
+						<li class="list-group-item">{task.args_schema_version || '-'}</li>
+						<li class="list-group-item list-group-item-light fw-bold">Args Schema</li>
+						<li class="list-group-item">
+							{#if task.args_schema}
 								<code>
-									<pre>{JSON.stringify(task?.args_schema, null, 2)}</pre>
+									<pre>{JSON.stringify(task.args_schema, null, 2)}</pre>
 								</code>
-								{:else}
+							{:else}
 								-
-								{/if}
-							</li>
-							<li class='list-group-item list-group-item-light fw-bold'>Docs Link</li>
-							<li class='list-group-item'>
-								{#if task?.docs_link}
-									<a href="{task?.docs_link}" target="_blank">{task?.docs_link}</a>
-								{:else}
+							{/if}
+						</li>
+						<li class="list-group-item list-group-item-light fw-bold">Docs Link</li>
+						<li class="list-group-item">
+							{#if task.docs_link}
+								<a href={task.docs_link} target="_blank">{task?.docs_link}</a>
+							{:else}
 								-
-								{/if}
-							</li>
-							<li class='list-group-item list-group-item-light fw-bold'>Docs Info</li>
-							<li class='list-group-item'>
-								{#if task?.docs_info}
-									{@html formatMarkdown(task?.docs_info)}
-								{:else}
+							{/if}
+						</li>
+						<li class="list-group-item list-group-item-light fw-bold">Docs Info</li>
+						<li class="list-group-item">
+							{#if task.docs_info}
+								{@html formatMarkdown(task.docs_info)}
+							{:else}
 								-
-								{/if}
-							</li>
-						</ul>
-					</div>
+							{/if}
+						</li>
+					</ul>
 				</div>
 			</div>
-			<div class="modal-footer">
-				<button class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-			</div>
 		</div>
-	</div>
-</div>
+		<div class="modal-footer">
+			<button class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+		</div>
+	{/if}
+</Modal>

--- a/src/lib/stores/taskStores.js
+++ b/src/lib/stores/taskStores.js
@@ -1,5 +1,7 @@
 import { writable } from 'svelte/store';
 
+/** @type {import('svelte/types/runtime/store').Writable<import('$lib/types').Task|undefined>} */
 export const taskStore = writable(undefined);
+/** @type {import('svelte/types/runtime/store').Writable<import('$lib/types').Task|undefined>} */
 export const originalTaskStore = writable(undefined);
 export const modalTaskCollectionId = writable(undefined);

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -14,3 +14,8 @@ export type Task = {
   docs_link: string
   docs_info: string
 }
+
+export type WorkflowTask = {
+  id: number
+  meta: {[string]: any}
+}

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -10,12 +10,18 @@ export type Task = {
   owner: string
   source: string
   args_schema_version: string
-  args_schema: string
+  args_schema: object
   docs_link: string
   docs_info: string
+  meta: object
 }
 
 export type WorkflowTask = {
   id: number
-  meta: {[string]: any}
+  meta: object
+  args: object
+  order: number
+  workflow_id: number
+  task_id: number
+  task: Task
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,23 @@
 <script>
 	import { page } from '$app/stores';
+	import { navigating } from '$app/stores';
 
 	$: userLoggedIn = !!$page.data.userInfo;
 	$: server = $page.data.serverInfo || {};
+
+	// Detects page change
+	$: if ($navigating) cleanupModalBackdrop();
+
+	/**
+	 * Removes the modal backdrop that remains stuck at page change.
+	 */
+	function cleanupModalBackdrop() {
+		document.querySelector('.modal-backdrop')?.remove();
+		const body = document.querySelector('body');
+		body?.classList.remove('modal-open');
+		body?.style.removeProperty('overflow');
+		body?.style.removeProperty('padding-right');
+	}
 </script>
 
 <main>
@@ -35,7 +50,7 @@
 			</ul>
 		</div>
 	</nav>
-	<div class='container p-4'>
+	<div class="container p-4">
 		<slot />
 	</div>
 	<div class="container">

--- a/src/routes/projects/[projectId]/+page.svelte
+++ b/src/routes/projects/[projectId]/+page.svelte
@@ -47,6 +47,10 @@
 			}
 		});
 	}
+
+	function onEditProjectModalOpen() {
+		projectUpdatesSuccessMessage = '';
+	}
 </script>
 
 <div class="d-flex justify-content-between align-items-center">
@@ -87,7 +91,7 @@
 	</div>
 {/if}
 
-<Modal id="editProjectModal" centered={true} bind:this={editProjectModal}>
+<Modal id="editProjectModal" centered={true} bind:this={editProjectModal} onOpen={onEditProjectModalOpen}>
 	<svelte:fragment slot="header">
 		<h5 class="modal-title">Project properties</h5>
 	</svelte:fragment>

--- a/src/routes/projects/[projectId]/+page.svelte
+++ b/src/routes/projects/[projectId]/+page.svelte
@@ -1,9 +1,7 @@
 <script>
-	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import ProjectDatasetsList from '$lib/components/projects/ProjectDatasetsList.svelte';
 	import WorkflowsList from '$lib/components/projects/WorkflowsList.svelte';
-	import { displayStandardErrorAlert } from '$lib/common/errors';
 	import Modal from '$lib/components/common/Modal.svelte';
 
 	// Component properties
@@ -12,19 +10,9 @@
 	let projectUpdatesSuccess = undefined;
 
 	let updatedProjectName = '';
-	let projectPropertiesErrorAlert = undefined;
 
-	onMount(async () => {
-		// Remove old error when opening the modal
-		const editProjectModal = document.getElementById('editProjectModal');
-		if (editProjectModal) {
-			editProjectModal.addEventListener('show.bs.modal', () => {
-				if (projectPropertiesErrorAlert) {
-					projectPropertiesErrorAlert.hide();
-				}
-			});
-		}
-	});
+	/** @type {Modal} */
+	let editProjectModal;
 
 	async function handleProjectPropertiesUpdate() {
 		projectUpdatesSuccess = undefined;
@@ -33,9 +21,7 @@
 		}
 
 		// Remove old error
-		if (projectPropertiesErrorAlert) {
-			projectPropertiesErrorAlert.hide();
-		}
+		editProjectModal.hideErrorAlert();
 
 		const headers = new Headers();
 		headers.set('Content-Type', 'application/json');
@@ -60,7 +46,7 @@
 			project.name = result.name;
 		} else {
 			console.error('Error while updating project', result);
-			projectPropertiesErrorAlert = displayStandardErrorAlert(result, 'projectPropertiesError');
+			editProjectModal.displayErrorAlert(result);
 			projectUpdatesSuccess = false;
 		}
 	}
@@ -103,13 +89,12 @@
 	</div>
 {/if}
 
-<Modal id="editProjectModal" centered={true}>
-	<div class="modal-header">
+<Modal id="editProjectModal" centered={true} bind:this={editProjectModal}>
+	<svelte:fragment slot="header">
 		<h5 class="modal-title">Project properties</h5>
-		<button class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-	</div>
-	<div class="modal-body">
-		<div id="projectPropertiesError" />
+	</svelte:fragment>
+	<svelte:fragment slot="body">
+		<div id="errorAlert-editProjectModal" />
 		{#if project}
 			<form id="updateProject" on:submit|preventDefault={handleProjectPropertiesUpdate}>
 				<div class="mb-3">
@@ -125,8 +110,8 @@
 				</div>
 			</form>
 		{/if}
-	</div>
-	<div class="modal-footer">
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
 		{#if projectUpdatesSuccess}
 			<div class="m-2 p-2 alert alert-success d-flex align-items-center">
 				<i class="bi bi-check-circle" />
@@ -134,5 +119,5 @@
 			</div>
 		{/if}
 		<button class="btn btn-primary" form="updateProject">Save</button>
-	</div>
+	</svelte:fragment>
 </Modal>

--- a/src/routes/projects/[projectId]/+page.svelte
+++ b/src/routes/projects/[projectId]/+page.svelte
@@ -4,6 +4,7 @@
 	import ProjectDatasetsList from '$lib/components/projects/ProjectDatasetsList.svelte';
 	import WorkflowsList from '$lib/components/projects/WorkflowsList.svelte';
 	import { displayStandardErrorAlert } from '$lib/common/errors';
+	import Modal from '$lib/components/common/Modal.svelte';
 
 	// Component properties
 	let project = $page.data.project;
@@ -102,40 +103,36 @@
 	</div>
 {/if}
 
-<div class="modal" id="editProjectModal">
-	<div class="modal-dialog modal-dialog-centered">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h5 class="modal-title">Project properties</h5>
-				<button class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-			</div>
-			<div class="modal-body">
-				<div id="projectPropertiesError" />
-				{#if project}
-					<form id="updateProject" on:submit|preventDefault={handleProjectPropertiesUpdate}>
-						<div class="mb-3">
-							<label for="projectName" class="form-label">Project name</label>
-							<input
-								type="text"
-								class="form-control"
-								name="projectName"
-								id="projectName"
-								bind:value={updatedProjectName}
-								required
-							/>
-						</div>
-					</form>
-				{/if}
-			</div>
-			<div class="modal-footer">
-				{#if projectUpdatesSuccess}
-					<div class="m-2 p-2 alert alert-success d-flex align-items-center">
-						<i class="bi bi-check-circle" />
-						<div class="ms-2">Properties updated</div>
-					</div>
-				{/if}
-				<button class="btn btn-primary" form="updateProject">Save</button>
-			</div>
-		</div>
+<Modal id="editProjectModal" centered={true}>
+	<div class="modal-header">
+		<h5 class="modal-title">Project properties</h5>
+		<button class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
 	</div>
-</div>
+	<div class="modal-body">
+		<div id="projectPropertiesError" />
+		{#if project}
+			<form id="updateProject" on:submit|preventDefault={handleProjectPropertiesUpdate}>
+				<div class="mb-3">
+					<label for="projectName" class="form-label">Project name</label>
+					<input
+						type="text"
+						class="form-control"
+						name="projectName"
+						id="projectName"
+						bind:value={updatedProjectName}
+						required
+					/>
+				</div>
+			</form>
+		{/if}
+	</div>
+	<div class="modal-footer">
+		{#if projectUpdatesSuccess}
+			<div class="m-2 p-2 alert alert-success d-flex align-items-center">
+				<i class="bi bi-check-circle" />
+				<div class="ms-2">Properties updated</div>
+			</div>
+		{/if}
+		<button class="btn btn-primary" form="updateProject">Save</button>
+	</div>
+</Modal>

--- a/src/routes/projects/[projectId]/+page.svelte
+++ b/src/routes/projects/[projectId]/+page.svelte
@@ -3,11 +3,13 @@
 	import ProjectDatasetsList from '$lib/components/projects/ProjectDatasetsList.svelte';
 	import WorkflowsList from '$lib/components/projects/WorkflowsList.svelte';
 	import Modal from '$lib/components/common/Modal.svelte';
+	import StandardDismissableAlert from '$lib/components/common/StandardDismissableAlert.svelte';
+	import { AlertError } from '$lib/common/errors';
 
 	// Component properties
 	let project = $page.data.project;
 	let workflows = $page.data.workflows;
-	let projectUpdatesSuccess = undefined;
+	let projectUpdatesSuccessMessage = '';
 
 	let updatedProjectName = '';
 
@@ -15,40 +17,35 @@
 	let editProjectModal;
 
 	async function handleProjectPropertiesUpdate() {
-		projectUpdatesSuccess = undefined;
-		if (!updatedProjectName) {
-			return;
-		}
+		editProjectModal.confirmAndHide(async () => {
+			projectUpdatesSuccessMessage = '';
+			if (!updatedProjectName) {
+				return;
+			}
 
-		// Remove old error
-		editProjectModal.hideErrorAlert();
+			const headers = new Headers();
+			headers.set('Content-Type', 'application/json');
 
-		const headers = new Headers();
-		headers.set('Content-Type', 'application/json');
+			const response = await fetch(`/api/v1/project/${project.id}`, {
+				method: 'PATCH',
+				credentials: 'include',
+				mode: 'cors',
+				headers,
+				body: JSON.stringify({
+					name: updatedProjectName
+				})
+			});
 
-		const response = await fetch(`/api/v1/project/${project.id}`, {
-			method: 'PATCH',
-			credentials: 'include',
-			mode: 'cors',
-			headers,
-			body: JSON.stringify({
-				name: updatedProjectName
-			})
+			const result = await response.json();
+			if (response.ok) {
+				console.log('Project updated successfully');
+				projectUpdatesSuccessMessage = 'Project properties successfully updated';
+				project.name = result.name;
+			} else {
+				console.error('Error while updating project', result);
+				throw new AlertError(result);
+			}
 		});
-
-		const result = await response.json();
-		if (response.ok) {
-			console.log('Project updated successfully');
-			projectUpdatesSuccess = true;
-			setTimeout(() => {
-				projectUpdatesSuccess = undefined;
-			}, 3000);
-			project.name = result.name;
-		} else {
-			console.error('Error while updating project', result);
-			editProjectModal.displayErrorAlert(result);
-			projectUpdatesSuccess = false;
-		}
 	}
 </script>
 
@@ -84,6 +81,7 @@
 			<h1>Project {project.name} #{project.id}</h1>
 		</div>
 
+		<StandardDismissableAlert message={projectUpdatesSuccessMessage} />
 		<ProjectDatasetsList datasets={project.dataset_list} />
 		<WorkflowsList {workflows} projectId={project.id} />
 	</div>
@@ -112,12 +110,6 @@
 		{/if}
 	</svelte:fragment>
 	<svelte:fragment slot="footer">
-		{#if projectUpdatesSuccess}
-			<div class="m-2 p-2 alert alert-success d-flex align-items-center">
-				<i class="bi bi-check-circle" />
-				<div class="ms-2">Properties updated</div>
-			</div>
-		{/if}
 		<button class="btn btn-primary" form="updateProject">Save</button>
 	</svelte:fragment>
 </Modal>

--- a/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
+++ b/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
@@ -261,11 +261,10 @@
 	bind:this={createDatasetResourceModal}
 	onOpen={onCreateDatasetResourceModalOpen}
 >
-	<div class="modal-header">
+	<svelte:fragment slot="header">
 		<h5 class="modal-title">Create dataset resource</h5>
-		<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-	</div>
-	<div class="modal-body">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<form on:submit|preventDefault={handleCreateDatasetResource}>
 			<div id="errorAlert-createDatasetResourceModal" />
 			<div class="mb-3">
@@ -279,63 +278,69 @@
 				<p class="alert alert-success mt-3">Resource created</p>
 			{/if}
 		</form>
-	</div>
+	</svelte:fragment>
 </Modal>
 
 {#if dataset}
-	<Modal id="updateDatasetModal" size="lg" centered={true} scrollable={true} bind:this={updateDatasetModal}>
-		<div class="modal-header">
+	<Modal
+		id="updateDatasetModal"
+		size="lg"
+		centered={true}
+		scrollable={true}
+		bind:this={updateDatasetModal}
+	>
+		<svelte:fragment slot="header">
 			<h5 class="modal-title">Update dataset properties</h5>
-			<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-		</div>
-		<form class="modal-body" on:submit|preventDefault={handleDatasetUpdate}>
-			<div id="errorAlert-updateDatasetModal" />
-			<div class="mb-3">
-				<label for="name" class="form-label">Dataset name</label>
-				<input
-					class="form-control"
-					type="text"
-					name="name"
-					id="name"
-					class:is-invalid={!name}
-					bind:value={name}
-				/>
-				{#if !name}
-					<div class="invalid-feedback">The dataset name can not be empty</div>
-				{/if}
-			</div>
-			<div class="mb-3">
-				<label for="type" class="form-label">Dataset type</label>
-				<input class="form-control" type="text" name="type" id="type" bind:value={type} />
-			</div>
-			<div class="mb-3">
-				<input
-					class="form-check-input"
-					type="checkbox"
-					name="read_only"
-					id="read_only"
-					bind:checked={read_only}
-				/>
-				<label for="read_only" class="form-check-label">Readonly dataset?</label>
-			</div>
+		</svelte:fragment>
+		<svelte:fragment slot="body">
+			<form on:submit|preventDefault={handleDatasetUpdate}>
+				<div id="errorAlert-updateDatasetModal" />
+				<div class="mb-3">
+					<label for="name" class="form-label">Dataset name</label>
+					<input
+						class="form-control"
+						type="text"
+						name="name"
+						id="name"
+						class:is-invalid={!name}
+						bind:value={name}
+					/>
+					{#if !name}
+						<div class="invalid-feedback">The dataset name can not be empty</div>
+					{/if}
+				</div>
+				<div class="mb-3">
+					<label for="type" class="form-label">Dataset type</label>
+					<input class="form-control" type="text" name="type" id="type" bind:value={type} />
+				</div>
+				<div class="mb-3">
+					<input
+						class="form-check-input"
+						type="checkbox"
+						name="read_only"
+						id="read_only"
+						bind:checked={read_only}
+					/>
+					<label for="read_only" class="form-check-label">Readonly dataset?</label>
+				</div>
 
-			<div class="d-flex align-items-center">
-				<button class="btn btn-primary me-3" type="submit" disabled={!name}>Update</button>
-				{#if updateDatasetSuccess}
-					<span class="text-success">Dataset properties updated with success</span>
-				{/if}
-			</div>
-		</form>
+				<div class="d-flex align-items-center">
+					<button class="btn btn-primary me-3" type="submit" disabled={!name}>Update</button>
+					{#if updateDatasetSuccess}
+						<span class="text-success">Dataset properties updated with success</span>
+					{/if}
+				</div>
+			</form>
+		</svelte:fragment>
 	</Modal>
 {/if}
 
 {#if dataset && Object.keys(dataset.meta).length > 0}
 	<Modal id="datasetMetaModal" size="lg" centered={true} scrollable={true}>
-		<div class="modal-header">
+		<svelte:fragment slot="header">
 			<h5 class="modal-title">Dataset meta properties</h5>
-			<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-		</div>
-		<div class="modal-body">
+		</svelte:fragment>
+		<svelte:fragment slot="body">
 			<ul class="list-group">
 				{#each Object.entries(dataset.meta) as [key, value]}
 					<li class="list-group-item text-bg-light">
@@ -356,7 +361,7 @@
 					</li>
 				{/each}
 			</ul>
-		</div>
+		</svelte:fragment>
 	</Modal>
 {/if}
 

--- a/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
+++ b/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import ConfirmActionButton from '$lib/components/common/ConfirmActionButton.svelte';
 	import { AlertError, displayStandardErrorAlert } from '$lib/common/errors';
+	import Modal from '$lib/components/common/Modal.svelte';
 
 	let projectId = $page.params.projectId;
 	let datasetId = $page.params.datasetId;
@@ -243,123 +244,111 @@
 	</div>
 {/if}
 
-<div class="modal" id="createDatasetResourceModal">
-	<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
-		<div class="modal-content">
-			<div class="modal-header">
-				<h5 class="modal-title">Create dataset resource</h5>
-				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-			</div>
-			<div class="modal-body">
-				<form on:submit|preventDefault={handleCreateDatasetResource}>
-					<div id="createDatasetResourceError" />
-					<div class="mb-3">
-						<label for="source" class="form-label">Resource path</label>
-						<input class="form-control" type="text" name="source" id="source" bind:value={source} />
-					</div>
-					<button class="btn btn-primary" disabled={!source} type="submit">
-						Create new resource
-					</button>
-					{#if createResourceSuccess}
-						<p class="alert alert-success mt-3">Resource created</p>
-					{/if}
-				</form>
-			</div>
-		</div>
+<Modal id="createDatasetResourceModal" size="lg" centered={true} scrollable={true}>
+	<div class="modal-header">
+		<h5 class="modal-title">Create dataset resource</h5>
+		<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
 	</div>
-</div>
+	<div class="modal-body">
+		<form on:submit|preventDefault={handleCreateDatasetResource}>
+			<div id="createDatasetResourceError" />
+			<div class="mb-3">
+				<label for="source" class="form-label">Resource path</label>
+				<input class="form-control" type="text" name="source" id="source" bind:value={source} />
+			</div>
+			<button class="btn btn-primary" disabled={!source} type="submit">
+				Create new resource
+			</button>
+			{#if createResourceSuccess}
+				<p class="alert alert-success mt-3">Resource created</p>
+			{/if}
+		</form>
+	</div>
+</Modal>
 
 {#if dataset}
-	<div class="modal" id="updateDatasetModal">
-		<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
-			<div class="modal-content">
-				<div class="modal-header">
-					<h5 class="modal-title">Update dataset properties</h5>
-					<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-				</div>
-				<div class="modal-body">
-					<div id="updateDatasetError" />
-					<div class="mb-3">
-						<label for="name" class="form-label">Dataset name</label>
-						<input
-							class="form-control"
-							type="text"
-							name="name"
-							id="name"
-							class:is-invalid={!name}
-							bind:value={name}
-						/>
-						{#if !name}
-							<div class="invalid-feedback">The dataset name can not be empty</div>
-						{/if}
-					</div>
-					<div class="mb-3">
-						<label for="type" class="form-label">Dataset type</label>
-						<input class="form-control" type="text" name="type" id="type" bind:value={type} />
-					</div>
-					<div class="mb-3">
-						<input
-							class="form-check-input"
-							type="checkbox"
-							name="read_only"
-							id="read_only"
-							bind:checked={read_only}
-						/>
-						<label for="read_only" class="form-check-label">Readonly dataset?</label>
-					</div>
+	<Modal id="updateDatasetModal" size="lg" centered={true} scrollable={true}>
+		<div class="modal-header">
+			<h5 class="modal-title">Update dataset properties</h5>
+			<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
+		</div>
+		<div class="modal-body">
+			<div id="updateDatasetError" />
+			<div class="mb-3">
+				<label for="name" class="form-label">Dataset name</label>
+				<input
+					class="form-control"
+					type="text"
+					name="name"
+					id="name"
+					class:is-invalid={!name}
+					bind:value={name}
+				/>
+				{#if !name}
+					<div class="invalid-feedback">The dataset name can not be empty</div>
+				{/if}
+			</div>
+			<div class="mb-3">
+				<label for="type" class="form-label">Dataset type</label>
+				<input class="form-control" type="text" name="type" id="type" bind:value={type} />
+			</div>
+			<div class="mb-3">
+				<input
+					class="form-check-input"
+					type="checkbox"
+					name="read_only"
+					id="read_only"
+					bind:checked={read_only}
+				/>
+				<label for="read_only" class="form-check-label">Readonly dataset?</label>
+			</div>
 
-					<div class="d-flex align-items-center">
-						<button
-							class="btn btn-primary me-3"
-							type="button"
-							on:click={handleDatasetUpdate}
-							disabled={!name}
-						>
-							Update
-						</button>
-						{#if updateDatasetSuccess}
-							<span class="text-success">Dataset properties updated with success</span>
-						{/if}
-					</div>
-				</div>
+			<div class="d-flex align-items-center">
+				<button
+					class="btn btn-primary me-3"
+					type="button"
+					on:click={handleDatasetUpdate}
+					disabled={!name}
+				>
+					Update
+				</button>
+				{#if updateDatasetSuccess}
+					<span class="text-success">Dataset properties updated with success</span>
+				{/if}
 			</div>
 		</div>
-	</div>
+	</Modal>
 {/if}
 
 {#if dataset && Object.keys(dataset.meta).length > 0}
-	<div class="modal" id="datasetMetaModal">
-		<div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
-			<div class="modal-content">
-				<div class="modal-header">
-					<h5 class="modal-title">Dataset meta properties</h5>
-					<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-				</div>
-				<div class="modal-body">
-					<ul class="list-group">
-						{#each Object.entries(dataset.meta) as [key, value]}
-							<li class="list-group-item text-bg-light">
-								<span class="text-capitalize">{key}</span>
-							</li>
-							<li class="list-group-item text-break">
-								{#if value === null}
-									<span>-</span>
-								{:else if typeof value == 'object'}
-									{#if Object.keys(value).length > 1}
-										<code><pre>{JSON.stringify(value, null, 2)}</pre></code>
-									{:else}
-										<code><pre>{JSON.stringify(value, null)}</pre></code>
-									{/if}
-								{:else}
-									<code>{value}</code>
-								{/if}
-							</li>
-						{/each}
-					</ul>
-				</div>
-			</div>
+	<Modal id="datasetMetaModal" size="lg" centered={true} scrollable={true}>
+		<div class="modal-header">
+			<h5 class="modal-title">Dataset meta properties</h5>
+			<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
 		</div>
-	</div>
+		<div class="modal-body">
+			<ul class="list-group">
+				{#each Object.entries(dataset.meta) as [key, value]}
+					<li class="list-group-item text-bg-light">
+						<span class="text-capitalize">{key}</span>
+					</li>
+					<li class="list-group-item text-break">
+						{#if value === null}
+							<span>-</span>
+						{:else if typeof value == 'object'}
+							{#if Object.keys(value).length > 1}
+								<code><pre>{JSON.stringify(value, null, 2)}</pre></code>
+							{:else}
+								<code><pre>{JSON.stringify(value, null)}</pre></code>
+							{/if}
+						{:else}
+							<code>{value}</code>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		</div>
+	</Modal>
 {/if}
 
 <style type="text/css">

--- a/src/routes/projects/[projectId]/workflows/[workflowId]/+page.svelte
+++ b/src/routes/projects/[projectId]/workflows/[workflowId]/+page.svelte
@@ -9,7 +9,7 @@
 	import ArgumentsSchema from '$lib/components/workflow/ArgumentsSchema.svelte';
 	import WorkflowTaskSelection from '$lib/components/workflow/WorkflowTaskSelection.svelte';
 	import { formatMarkdown, replaceEmptyStrings } from '$lib/common/component_utilities';
-	import { AlertError, displayStandardErrorAlert } from '$lib/common/errors';
+	import { AlertError } from '$lib/common/errors';
 	import Modal from '$lib/components/common/Modal.svelte';
 	import StandardDismissableAlert from '$lib/components/common/StandardDismissableAlert.svelte';
 

--- a/src/routes/projects/[projectId]/workflows/[workflowId]/+page.svelte
+++ b/src/routes/projects/[projectId]/workflows/[workflowId]/+page.svelte
@@ -703,11 +703,10 @@
 {/if}
 
 <Modal id="insertTaskModal" centered={true}>
-	<div class="modal-header">
+	<svelte:fragment slot="header">
 		<h5 class="modal-title">New workflow task</h5>
-		<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-	</div>
-	<div class="modal-body">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<div id="workflowTaskError" />
 		<form on:submit|preventDefault={handleCreateWorkflowTask}>
 			<div class="mb-3">
@@ -730,20 +729,19 @@
 
 			<button class="btn btn-primary" type="submit">Insert</button>
 		</form>
-	</div>
-	<div class="modal-footer d-flex">
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
 		{#if workflowTaskCreated}
 			<span class="w-100 alert alert-success">Workflow task created</span>
 		{/if}
-	</div>
+	</svelte:fragment>
 </Modal>
 
 <Modal id="editWorkflowModal" centered={true}>
-	<div class="modal-header">
+	<svelte:fragment slot="header">
 		<h5 class="modal-title">Workflow properties</h5>
-		<button class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-	</div>
-	<div class="modal-body">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<div id="updatedWorkflowError" />
 		{#if workflow}
 			<form id="updateWorkflow" on:submit|preventDefault={handleWorkflowUpdate}>
@@ -759,21 +757,20 @@
 				</div>
 			</form>
 		{/if}
-	</div>
-	<div class="modal-footer">
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
 		{#if workflowUpdated}
 			<span class="alert alert-success">Workflow updated correctly</span>
 		{/if}
 		<button class="btn btn-primary" form="updateWorkflow">Save</button>
-	</div>
+	</svelte:fragment>
 </Modal>
 
 <Modal id="editWorkflowTasksOrderModal" centered={true} bind:this={editWorkflowTasksOrderModal}>
-	<div class="modal-header">
+	<svelte:fragment slot="header">
 		<h5 class="modal-title">Edit workflow tasks order</h5>
-		<button class="btn-close" data-bs-dismiss="modal" />
-	</div>
-	<div class="modal-body">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<div id="errorAlert-editWorkflowTasksOrderModal" />
 		{#if workflow !== undefined && updatableWorkflowList.length == 0}
 			<p class="text-center mt-3">No workflow tasks yet, add one.</p>
@@ -810,20 +807,19 @@
 				</ul>
 			{/key}
 		{/if}
-	</div>
-	<div class="modal-footer">
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
 		<button class="btn btn-primary" on:click|preventDefault={handleWorkflowOrderUpdate}>
 			Save
 		</button>
-	</div>
+	</svelte:fragment>
 </Modal>
 
 <Modal id="runWorkflowModal" centered={true} bind:this={runWorkflowModal}>
-	<div class="modal-header">
+	<svelte:fragment slot="header">
 		<h5 class="modal-title">Run workflow</h5>
-		<button class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-	</div>
-	<div class="modal-body">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<div id="errorAlert-runWorkflowModal" />
 		<form id="runWorkflowForm">
 			<div class="mb-3">
@@ -901,8 +897,8 @@
 				/>
 			</div>
 		</form>
-	</div>
-	<div class="modal-footer">
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
 		{#if checkingConfiguration}
 			<button
 				class="btn btn-warning"
@@ -921,20 +917,19 @@
 				}}>Run</button
 			>
 		{/if}
-	</div>
+	</svelte:fragment>
 </Modal>
 
 <Modal id="changes-unsaved-dialog" bind:this={unsavedChangesModal}>
-	<div class="modal-header">
+	<svelte:fragment slot="header">
 		<h5 class="modal-title">There are argument changes unsaved</h5>
-		<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
-	</div>
-	<div class="modal-body">
+	</svelte:fragment>
+	<svelte:fragment slot="body">
 		<p>
 			Do you want to save the changes made to the arguments of the current selected workflow task?
 		</p>
-	</div>
-	<div class="modal-footer">
+	</svelte:fragment>
+	<svelte:fragment slot="footer">
 		<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
 		<button
 			type="button"
@@ -953,5 +948,5 @@
 			data-bs-dismiss="modal"
 			>Save changes
 		</button>
-	</div>
+	</svelte:fragment>
 </Modal>

--- a/src/routes/projects/[projectId]/workflows/[workflowId]/+page.svelte
+++ b/src/routes/projects/[projectId]/workflows/[workflowId]/+page.svelte
@@ -358,7 +358,7 @@
 			editWorkflowTasksOrderModal.toggle();
 		} else {
 			console.error('Workflow task order not updated', result);
-			displayStandardErrorAlert(result, 'workflowTasksOrderError');
+			editWorkflowTasksOrderModal.displayErrorAlert(result);
 		}
 	}
 
@@ -367,16 +367,18 @@
 	 * @returns {Promise<void>}
 	 */
 	async function handleApplyWorkflow() {
+		// reset previous errors
+		runWorkflowModal.hideErrorAlert();
 		if (inputDatasetControl === '') {
 			// Preliminary check: if inputDatasetControl is not set, raise an error
 			let message = 'Input dataset is required. Select one from the list.';
 			console.error(message);
-			displayStandardErrorAlert(message, 'applyWorkflowError');
+			runWorkflowModal.displayErrorAlert(message);
 		} else if (outputDatasetControl === '') {
 			// Preliminary check: if outputDatasetControl is not set, raise an error
 			let message = 'Output dataset is required. Select one from the list.';
 			console.error(message);
-			displayStandardErrorAlert(message, 'applyWorkflowError');
+			runWorkflowModal.displayErrorAlert(message);
 		} else {
 			// Both inputDatasetControl and outputDatasetControl are set, continue
 			const requestBody = {
@@ -416,7 +418,7 @@
 			} else {
 				console.error(response);
 				// Set an error message on the component
-				displayStandardErrorAlert(await response.json(), 'applyWorkflowError');
+				runWorkflowModal.displayErrorAlert(await response.json());
 			}
 		}
 	}
@@ -772,7 +774,7 @@
 		<button class="btn-close" data-bs-dismiss="modal" />
 	</div>
 	<div class="modal-body">
-		<div id="workflowTasksOrderError" />
+		<div id="errorAlert-editWorkflowTasksOrderModal" />
 		{#if workflow !== undefined && updatableWorkflowList.length == 0}
 			<p class="text-center mt-3">No workflow tasks yet, add one.</p>
 		{:else if workflow !== undefined}
@@ -788,7 +790,7 @@
 									{#if i !== 0}
 										<button
 											class="btn btn-light"
-											on:click|preventDefault={() => moveWorkflowTask.bind(i, 'up')}
+											on:click|preventDefault={() => moveWorkflowTask(i, 'up')}
 										>
 											<i class="bi-arrow-up" />
 										</button>
@@ -810,8 +812,9 @@
 		{/if}
 	</div>
 	<div class="modal-footer">
-		<button class="btn btn-primary" on:click|preventDefault={handleWorkflowOrderUpdate}>Save</button
-		>
+		<button class="btn btn-primary" on:click|preventDefault={handleWorkflowOrderUpdate}>
+			Save
+		</button>
 	</div>
 </Modal>
 
@@ -821,7 +824,7 @@
 		<button class="btn-close" data-bs-dismiss="modal" aria-label="Close" />
 	</div>
 	<div class="modal-body">
-		<div id="applyWorkflowError" />
+		<div id="errorAlert-runWorkflowModal" />
 		<form id="runWorkflowForm">
 			<div class="mb-3">
 				<label for="inputDataset" class="form-label">Input dataset</label>


### PR DESCRIPTION
## Checklist before merging
- [X] I added an appropriate entry to `CHANGELOG.md`

I introduced a new generic `Modal` component on which the developer can attach functions to the Bootstrap modal events, so that we can detect the modal closure regardless of the chosen mode (button, esc key, click on backdrop). It also provides generic methods for displaying an error inside the modal and automatically cleaning up the previous errors if the modal is closed and then opened again.

After this refactoring the delete workflow confirm modal behaves like delete dataset confirm modal: the error is always displayed inside the modal and the modal is not closed when an error happens.

Moreover, it was now possible to remove the static backdrop mentioned in #264, meaning that now the edit task modal can be closed in all the possible ways.

I've also investigated the issue of the backdrop remaining stuck when clicking on the back browser button. It seems to be related to Svelte invalidation not being triggered for the modal when going to the previous page and I fixed it adding a check directly in the layout page.

All the modals involved in the refactoring:

* generic confirm action
* edit task (it is now possible to close the modal in all the possible ways)
* import workflow
* create dataset resource
* update datatset
* job info
* job logs
* project info
* task collection logs
* task info
* edit project
* dataset meta properties
* unsaved changes
* new workflow task
* edit workflow properties
* change workflow task order
* run workflow

Closes #264
Closes #307