### PR TITLE
Add show-history button in dataset page (ref #309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 
+* Added dataset history modal (\#316).
 * Fixed bug with save/discard changes in workflow task (\#315).
 * Fixed first-run redirects issue (\#315).
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -36,9 +36,9 @@ export type Dataset = {
   name: string
   type?: string
   meta: object
-  history: object
+  history: Array<object>
   read_only: boolean
   id: number
-  resource_list: Resource[]
+  resource_list: Array<Resource>
   project_id: number
 }

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -36,6 +36,7 @@ export type Dataset = {
   name: string
   type?: string
   meta: object
+  history: object
   read_only: boolean
   id: number
   resource_list: Resource[]

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -32,11 +32,17 @@ export type Resource = {
   dataset_id: number
 }
 
+export type DatasetHistoryItem = {
+  workflowtask: WorkflowTask
+  status: string
+  parallelization: object
+}
+
 export type Dataset = {
   name: string
   type?: string
   meta: object
-  history: Array<object>
+  history: Array<DatasetHistoryItem>
   read_only: boolean
   id: number
   resource_list: Array<Resource>

--- a/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
+++ b/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
@@ -17,20 +17,20 @@
 	/**
 	 * Returns the dataset history formatted in JSON hiding some values.
 	 *
-	 * @param {object} value
+	 * @param {import('$lib/types').DatasetHistoryItem} historyItem
 	 * @returns {string}
 	 */
-	function formatDatasetHistory(value) {
+	function formatDatasetHistory(historyItem) {
 		return JSON.stringify(
 			{
-				...value,
+				...historyItem,
 				workflowtask: {
-					...value.workflowtask,
+					...historyItem.workflowtask,
 					task: {
-						...value.workflowtask.task,
-						args_schema: value.workflowtask.task.args_schema ? '[HIDDEN]' : undefined,
-						docs_info: value.workflowtask.task.docs_info ? '[HIDDEN]' : undefined,
-						docs_link: value.workflowtask.task.docs_link ? '[HIDDEN]' : undefined
+						...historyItem.workflowtask.task,
+						args_schema: historyItem.workflowtask.task.args_schema ? '[HIDDEN]' : undefined,
+						docs_info: historyItem.workflowtask.task.docs_info ? '[HIDDEN]' : undefined,
+						docs_link: historyItem.workflowtask.task.docs_link ? '[HIDDEN]' : undefined
 					}
 				}
 			},
@@ -173,7 +173,9 @@
 				{#if Object.keys(dataset.history).length > 0}
 					{#each Object.entries(dataset.history) as [key, value]}
 						<li class="list-group-item text-bg-light">
-							<span class="text-capitalize">History item {key}</span>
+							<span>
+								Task "{value.workflowtask.task.name}", status "{value.status}"
+							</span>
 						</li>
 						<li class="list-group-item text-break">
 							<code><pre>{formatDatasetHistory(value)}</pre></code>

--- a/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
+++ b/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
@@ -13,6 +13,31 @@
 	onMount(async () => {
 		dataset = await $page.data.dataset;
 	});
+
+	/**
+	 * Returns the dataset history formatted in JSON hiding some values.
+	 *
+	 * @param {object} value
+	 * @returns {string}
+	 */
+	function formatDatasetHistory(value) {
+		return JSON.stringify(
+			{
+				...value,
+				workflowtask: {
+					...value.workflowtask,
+					task: {
+						...value.workflowtask.task,
+						args_schema: value.workflowtask.task.args_schema ? '[HIDDEN]' : undefined,
+						docs_info: value.workflowtask.task.docs_info ? '[HIDDEN]' : undefined,
+						docs_link: value.workflowtask.task.docs_link ? '[HIDDEN]' : undefined
+					}
+				}
+			},
+			null,
+			2
+		);
+	}
 </script>
 
 <div class="d-flex justify-content-between align-items-center">
@@ -139,7 +164,7 @@
 			</ul>
 		</svelte:fragment>
 	</Modal>
-	<Modal id="datasetHistoryModal" size="lg" centered={true} scrollable={true}>
+	<Modal id="datasetHistoryModal" size="xl" centered={true} scrollable={true}>
 		<svelte:fragment slot="header">
 			<h5 class="modal-title">Dataset history</h5>
 		</svelte:fragment>
@@ -151,7 +176,7 @@
 							<span class="text-capitalize">History item {key}</span>
 						</li>
 						<li class="list-group-item text-break">
-							<code><pre>{JSON.stringify(value, null, 2)}</pre></code>
+							<code><pre>{formatDatasetHistory(value)}</pre></code>
 						</li>
 					{/each}
 				{:else}
@@ -164,6 +189,7 @@
 
 <style type="text/css">
 	pre {
+		white-space: pre-wrap;
 		display: inline;
 	}
 </style>

--- a/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
+++ b/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
@@ -34,7 +34,11 @@
 		{#if dataset}
 			<button class="btn btn-light" data-bs-target="#datasetMetaModal" data-bs-toggle="modal">
 				<i class="bi-arrow-up-right-square" />
-				Show meta properties
+				Show dataset metadata
+			</button>
+			<button class="btn btn-light" data-bs-target="#datasetHistoryModal" data-bs-toggle="modal">
+				<i class="bi-arrow-up-right-square" />
+				Show dataset history
 			</button>
 		{/if}
 	</div>
@@ -131,6 +135,27 @@
 					{/each}
 				{:else}
 					<p>No meta properties</p>
+				{/if}
+			</ul>
+		</svelte:fragment>
+	</Modal>
+	<Modal id="datasetHistoryModal" size="lg" centered={true} scrollable={true}>
+		<svelte:fragment slot="header">
+			<h5 class="modal-title">Dataset history</h5>
+		</svelte:fragment>
+		<svelte:fragment slot="body">
+			<ul class="list-group">
+				{#if Object.keys(dataset.history).length > 0}
+					{#each Object.entries(dataset.history) as [key, value]}
+						<li class="list-group-item text-bg-light">
+							<span class="text-capitalize">History item {key}</span>
+						</li>
+						<li class="list-group-item text-break">
+							<code><pre>{JSON.stringify(value, null, 2)}</pre></code>
+						</li>
+					{/each}
+				{:else}
+					<p>No history</p>
 				{/if}
 			</ul>
 		</svelte:fragment>

--- a/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
+++ b/src/routes/projects/[projectId]/datasets/[datasetId]/+page.svelte
@@ -170,7 +170,7 @@
 		</svelte:fragment>
 		<svelte:fragment slot="body">
 			<ul class="list-group">
-				{#if Object.keys(dataset.history).length > 0}
+				{#if dataset.history && Object.keys(dataset.history).length > 0}
 					{#each Object.entries(dataset.history) as [key, value]}
 						<li class="list-group-item text-bg-light">
 							<span>


### PR DESCRIPTION
I'm adding this feature in an experimental way, as it's useful for testing the upcoming (unreleased, as of now) fractal-server version, based on https://github.com/fractal-analytics-platform/fractal-server/pull/898.

Here are some screenshots of how it would look:
![image](https://github.com/fractal-analytics-platform/fractal-web/assets/3862206/791fc974-a6e3-46f8-82c7-355a8d34d3b0)
![image](https://github.com/fractal-analytics-platform/fractal-web/assets/3862206/1742de2b-cb8c-4ca9-9bd7-2c9365c4b74c)

I think we will need to slightly decrease the amount of information shown in there.
The simplest way would be to hide the `args_schema` property (or replace it with the string "HIDDEN", or something like that). Each history item has a required `workflowtask` property, then a required `task` property, then an optional `args_schema` property. If `item.workflowtask.task.args_schema` exists, we could modify it.


## Checklist before merging
- [x] I added an appropriate entry to `CHANGELOG.md`
