### PR TITLE
Fixed argument popovers performance issue

### DIFF
--- a/.github/workflows/end_to_end_tests.yaml
+++ b/.github/workflows/end_to_end_tests.yaml
@@ -42,3 +42,6 @@ jobs:
           name: playwright-coverage
           path: coverage-playwright/
           retention-days: 30
+
+    env:
+      ENABLE_COVERAGE: "true"

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -33,3 +33,6 @@ jobs:
           name: unit-coverage
           path: coverage-unit/
           retention-days: 30
+
+    env:
+      ENABLE_COVERAGE: "true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 
+* Fixed argument popovers performance issue (\#324).
 * Added end to end tests and coverage configuration (\#320).
 
 # 0.6.1

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -21,12 +21,12 @@ To execute the tests seeing the browser add the `--headed` flag or the `--debug`
 Coverage for the unit tests:
 
 ```
-npx vitest run --coverage.enabled --coverage.provider=istanbul --coverage.include=src --coverage.reporter=json --coverage.all
+ENABLE_COVERAGE=true npx vitest run --coverage.enabled --coverage.provider=istanbul --coverage.include=src --coverage.reporter=json --coverage.all
 ```
 
 Warning: coverage takes some time using the option `--coverage.all`.
 
-Coverage for the playwright tests is automatically collected when running `npx playwright test`.
+Coverage for the playwright tests is automatically collected when running `ENABLE_COVERAGE=true npx playwright test`.
 
 To generate a merged html report:
 

--- a/src/lib/components/common/jschema/PropertyDescription.svelte
+++ b/src/lib/components/common/jschema/PropertyDescription.svelte
@@ -3,17 +3,27 @@
 
 	export let description = undefined;
 
-	onMount(() => {
-		const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]');
-		// eslint-disable-next-line no-undef
-		popoverTriggerList.forEach(popoverEl => new bootstrap.Popover(popoverEl));
-	});
+	let element;
 
+	onMount(() => {
+		if (element) {
+			// @ts-ignore
+			// eslint-disable-next-line no-undef
+			new bootstrap.Popover(element);
+		}
+	});
 </script>
 
-<span class='ms-2'>
-  {#if description }
-    <a tabindex='0' role='button' data-bs-trigger='focus' class='bi bi-info-circle' data-bs-toggle='popover'
-       data-bs-content={description}></a>
-  {/if}
+<span class="ms-2 property-description">
+	{#if description}
+		<span
+			bind:this={element}
+			tabindex="0"
+			role="button"
+			data-bs-trigger="focus"
+			class="bi bi-info-circle text-primary"
+			data-bs-toggle="popover"
+			data-bs-content={description}
+		/>
+	{/if}
 </span>

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,20 +7,26 @@ const packageJsonFile = fileURLToPath(new URL('package.json', import.meta.url));
 const packageJsonData = readFileSync(packageJsonFile);
 const pkg = JSON.parse(packageJsonData);
 
+const enableIstanbul = process.env['ENABLE_COVERAGE'];
+
 /** @type {import('vite').UserConfig} */
 const config = {
 	plugins: [
 		sveltekit(),
-		istanbul({
-			include: 'src/*',
-			exclude: ['node_modules', 'tests', 'static'],
-			extension: ['.js', '.svelte'],
-			requireEnv: false,
-			forceBuildInstrument: true
-		})
+		enableIstanbul &&
+			istanbul({
+				include: 'src/*',
+				exclude: ['node_modules', 'tests', 'static'],
+				extension: ['.js', '.svelte'],
+				requireEnv: false,
+				forceBuildInstrument: true
+			})
 	],
 	define: {
 		__APP_VERSION__: JSON.stringify(pkg.version)
+	},
+	build: {
+		sourcemap: true
 	},
 	test: {
 		globals: true,
@@ -28,7 +34,7 @@ const config = {
 		coverage: {
 			provider: 'istanbul',
 			reporter: ['text', 'json', 'html'],
-			reportsDirectory: './coverage-unit',
+			reportsDirectory: './coverage-unit'
 		}
 	},
 	optimizeDeps: {


### PR DESCRIPTION
## Checklist before merging
- [X] I added an appropriate entry to `CHANGELOG.md`

I've run the Firefox profiler using the workflow file provided by @jluethi in #322.

It detects that the performance issue is related to the file `PropertyDescription.svelte`:

![Screenshot from 2023-10-24 08-50-18](https://github.com/fractal-analytics-platform/fractal-web/assets/5459334/7e3fac4d-53d6-4551-a185-6e4f6b15fe42)

That component displays the description of each argument inside a popover. However it was initializing every time all the popovers of the page for each component, resulting in a huge number of popover initialization. With this PR only the popover contained in the component is initialized.
